### PR TITLE
Create In CI, you can either skip deploying (no wallet needed) or giv…

### DIFF
--- a/In CI, you can either skip deploying (no wallet needed) or give it a dummy keypair.Add this before anchor build in your workflow:

+++ b/In CI, you can either skip deploying (no wallet needed) or give it a dummy keypair.Add this before anchor build in your workflow:

@@ -1,0 +1,4 @@
+- name: Create dummy Solana keypair
+  run: |
+    mkdir -p ~/.config/solana
+    echo '[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]' > ~/.config/solana/id.json


### PR DESCRIPTION
…e it a dummy keypair.Add this before anchor build in your workflow: