### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/anchor-ci.yml
+++ b/.github/workflows/anchor-ci.yml
@@ -1,4 +1,6 @@
 name: CI & Anchor Deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/4](https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/4)

To fix the flagged issue, explicitly specify a `permissions` block at the top (root) of your workflow YAML file. This block should grant only the minimum permissions required for the workflow. For most CI workflows that build, test, and deploy, but do not interact with repository contents (e.g., push, release, change issues/PRs), `contents: read` suffices.

- **Where to change:** Add the following block just beneath the workflow name declaration, before `on:`.
- **What to add:**  
  ```yaml
  permissions:
    contents: read
  ```
- **Details:**  
  This will limit the GITHUB_TOKEN to read-only access to repository contents, unless individual jobs explicitly override with additional permissions.
- **No new methods or imports required.**  
- **No change to workflow functionality.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
