### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/6](https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/6)

The best way to fix this problem is to add an explicit `permissions` block to the workflow. Since the workflow only checks out code, builds, and runs tests, it does not need any write permissions to repository contents, pull requests, or any other scopes. Therefore, we can safely add a `permissions` block with `contents: read` at the root level of the workflow. This ensures that the `GITHUB_TOKEN` that is automatically created will have only read access to the repository contents for all jobs, adhering to the principle of least privilege. Edit `.github/workflows/rust.yml`, and add the following block after the workflow `name` line (before `on`) for root-level default:  

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
