### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.v2.yml
+++ b/.github/workflows/rust.v2.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/9](https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/9)

To fix the problem, add a `permissions:` block at the root of the workflow (below the `name:` and before `on:`) to explicitly restrict the `GITHUB_TOKEN` permissions. The most minimal and generally safe default is `contents: read`, but if any workflow steps require additional privileges (such as write access to issues, PRs, or actions that use artifacts), these may need to be enumerated as well.  
For this fix, we'll follow best practices and add a block:
```yaml
permissions:
  contents: read
```
This limits the default job token permissions to read access for repository contents. If further permissions are demonstrably required by steps, they can be granted more granularly as needed.

Add this permission block at the top-level of the workflow, after the `name: Rust` and before `on:` (line 2).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
