### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow that is manually triggered
 
 name: Manual workflow
+permissions:
+  contents: read
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Potential fix for [https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/8](https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/8)

The recommended fix is to add an explicit `permissions:` block defining the minimum required GitHub token permissions. For most workflows that only read repository contents and do not need to write (such as creating releases, acting on issues, or modifying PRs), `permissions: contents: read` is a minimal and secure default. This block can be added at the root of the workflow (makes it apply to all jobs), or per job (for finer-grained control). In this file, add the following indented after `name:` (line 3):  
```yaml
permissions:
  contents: read
```
This ensures that workflow jobs do not receive write access by default. If later jobs need more permissions, those can be added explicitly.  
You only need to edit the shown .github/workflows/manual.yml.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
