### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -20,6 +20,9 @@
 #    action executes, check the 'Security' tab for results
 
 name: Appknox
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/7](https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow to ensure that the GITHUB_TOKEN has only the minimum set of permissions required. In this case, the workflow's only relevant write operation is the upload of a SARIF file (code scanning result) to GitHub Advanced Security, which requires `security-events: write`. All other steps (like `actions/checkout`, running Gradle, and using appknox/appknox-github-action) require only read access or no special permissions. The best place to add the `permissions` block is at the workflow root, so it covers the job and all steps, but if future jobs are added, you may want to scope the permissions per job as needed.

Add this near the top of the workflow (just after `name: Appknox`):  
```yaml
permissions:
  contents: read
  security-events: write
```
This allows the upload of SARIF files, while restricting access to the rest of the repository contents to read-only.

**Lines to change:**  
- After `name: Appknox` (line 22 or 23), insert the above `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
