### PR TITLE
Create If you only supply watch-list/sanctions screening, implement t…

### DIFF
--- a/If you only supply watch-list/sanctions screening, implement the smaller `AMLProvider` interface: AML-only providers   POST /aml/screen  
+++ b/If you only supply watch-list/sanctions screening, implement the smaller `AMLProvider` interface: AML-only providers   POST /aml/screen  
@@ -1,0 +1,6 @@
+{
+  "applicantId": "...",
+  "names": ["Alice A. Smith"],
+  "countries": ["DE", "US"],
+  "dob": ["1990-01-01"]
+}


### PR DESCRIPTION
…he smaller `AMLProvider` interface: AML-only providers   POST /aml/screen