### PR TITLE
Fix for Shift out of range

### DIFF
--- a/Identity Manager.ts
+++ b/Identity Manager.ts
@@ -3,10 +3,10 @@ import { PublicKey } from "@solana/web3.js";
 
 // Standard Bitmask Flags
 export enum ComplianceFlags {
-  US_ACCREDITED = 1 << 0,  // 1
-  EU_MICA        = 1 << 1,  // 2
-  INSTITUTIONAL  = 1 << 2,  // 4
-  SANCTIONED     = 1 << 63, // High bit for immediate blocking
+  US_ACCREDITED = 1 << 0,     // 1
+  EU_MICA        = 1 << 1,    // 2
+  INSTITUTIONAL  = 1 << 2,    // 4
+  SANCTIONED     = 0x80000000, // High 32-bit bit for immediate blocking
 }
 
 export class IdentityManager {


### PR DESCRIPTION
In general, to fix “shift out of range” issues in TypeScript/JavaScript, do not use `<<`/`>>`/`>>>` with shift counts ≥ 32 on `number` values. If you need a high‑order bit beyond 31, either (a) represent the flag as a `bigint` and use `1n << 63n`, or (b) use an alternative representation like a hexadecimal/decimal literal that fits within JavaScript’s safe integer range, and avoid bitwise operations that implicitly truncate to 32 bits.

Here, the rest of the code treats flags as `number`s, reduces them with `|`, and then passes them to `new anchor.BN(bitmask)`. Anchor’s `BN` can represent large values, but the bitwise OR operations on `number` are still limited to 32 bits. The least invasive fix that preserves current usage is to choose the highest safe 32‑bit flag bit explicitly (bit 31) rather than incorrectly attempting to use bit 63. That means replacing `1 << 63` with the equivalent *number literal* for bit 31, `0x80000000` (which equals `2_147_483_648`). This avoids an out‑of‑range shift, keeps the enum type as `number`, and keeps `updateComplianceBits` unchanged. If the intention truly was a 64‑bit mask, a larger refactor to use `bigint` for flags and mask construction would be required, but that would change existing interfaces and behavior; given the constraints, the minimal safe fix is to use a numeric literal for the high bit within the 32‑bit range.

Concretely, in `Identity Manager.ts`, on the `ComplianceFlags` enum, change the `SANCTIONED` value from `1 << 63` to `0x80000000` and keep the comment to clarify this is the top 32‑bit flag. No imports or other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._