### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Test Setup Files tests/setupAfterEnv.ts
+++ b/Test Setup Files tests/setupAfterEnv.ts
@@ -1,5 +1,3 @@
-import { Connection } from '@solana/web3.js';
-
 beforeAll(async () => {
   // Verify test connection
   try {


### PR DESCRIPTION
To fix the problem, remove the unused `Connection` import so that the file no longer declares a symbol that is never referenced. This keeps the existing functionality intact because the code uses `global.testConnection` and other globals, not the imported `Connection` type or value.

Concretely, in `tests/setupAfterEnv.ts`, delete line 1 that reads `import { Connection } from '@solana/web3.js';`. No additional imports, methods, or definitions are required, since nothing in the file depends on `Connection`. The rest of the file (the `beforeAll`, `afterAll`, and the global helpers) should remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._