### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/deploy-programs.ts
+++ b/deploy-programs.ts
@@ -12,7 +12,7 @@ import {
   Transaction,
   sendAndConfirmTransaction,
 } from '@solana/web3.js';
-import { AnchorProvider, Wallet, BN } from '@coral-xyz/anchor';
+import { AnchorProvider, Wallet } from '@coral-xyz/anchor';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'yaml';


### PR DESCRIPTION
To fix an unused-import problem, remove the unused symbol from the import statement (or start using it meaningfully if it was genuinely intended). Since we must avoid changing existing functionality and we have no evidence that `BN` should be used, the safest and simplest fix is to delete `BN` from the import list, leaving the rest of the code intact.

Concretely, in `deploy-programs.ts`, adjust the import on line 15 from `import { AnchorProvider, Wallet, BN } from '@coral-xyz/anchor';` to `import { AnchorProvider, Wallet } from '@coral-xyz/anchor';`. No other code changes, new methods, or additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._