### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/complete-workflow.test.ts
+++ b/complete-workflow.test.ts
@@ -9,8 +9,6 @@ import {
   Connection, 
   Keypair, 
   PublicKey, 
-  Transaction,
-  sendAndConfirmTransaction,
 } from '@solana/web3.js';
 import { AnchorProvider, Wallet, BN } from '@coral-xyz/anchor';
 import { ComplianceSDK, KycLevel, KycStatus } from '../../sdk/src/compliance-sdk';


### PR DESCRIPTION
In general, the fix for unused imports is to remove them from the import statement, leaving only the identifiers that are actually referenced in the file. This reduces noise, avoids potential linter errors, and does not alter runtime behavior since imports that are never used contribute nothing to execution.

For this specific file, we should edit the import from `@solana/web3.js` at the top of `complete-workflow.test.ts`. Currently it includes `Transaction` and `sendAndConfirmTransaction`. The best minimal fix is to remove these two names from the destructuring import while keeping `Connection`, `Keypair`, and `PublicKey` intact. No other code changes are required because there are no references to `Transaction` or `sendAndConfirmTransaction` elsewhere in the provided section, and the static analysis warning confirms they are unused in the whole file. No additional imports, helper methods, or type definitions are needed.

Concretely, in `complete-workflow.test.ts`, adjust lines 8–14 so the import from `@solana/web3.js` only includes `Connection`, `Keypair`, and `PublicKey`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._