### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/sdk/src/compliance-sdk.ts
+++ b/sdk/src/compliance-sdk.ts
@@ -1,4 +1,4 @@
-import { Connection, PublicKey, Signer, TransactionSignature } from '@solana/web3.js';
+import { TransactionSignature } from '@solana/web3.js';
 import { TransferHookService } from './services/transfer-hook-service';
 import {
   InitializeCompliantMintParams,


### PR DESCRIPTION
To fix the problem, we should remove the unused symbols from the import statement while preserving any actually used imports. Here, only `TransactionSignature` is referenced in the class method return types, so we should keep that and drop `Connection`, `PublicKey`, and `Signer`.

Concretely, in `sdk/src/compliance-sdk.ts`, edit the import on line 1 to only import `TransactionSignature` from `@solana/web3.js`. No other code changes are needed because the removed types are not referenced anywhere else in the snippet. We do not need any additional methods, definitions, or imports; this is purely a cleanup of the existing import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._