### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/sdk/src/services/transfer-hook-service.ts
+++ b/sdk/src/services/transfer-hook-service.ts
@@ -1,11 +1,9 @@
 import {
   Connection,
   PublicKey,
-  Signer,
   Transaction,
   TransactionSignature,
-  sendAndConfirmTransaction,
-  Keypair
+  sendAndConfirmTransaction
 } from '@solana/web3.js';
 import {
   InitializeCompliantMintParams,


### PR DESCRIPTION
To fix the issue, remove the unused `Signer` and `Keypair` symbols from the import list from `@solana/web3.js`. This keeps the file clean and resolves the CodeQL warning without changing any functionality.

Concretely, in `sdk/src/services/transfer-hook-service.ts`, edit the top import statement so that it only imports the identifiers actually used in this file: `Connection`, `PublicKey`, `Transaction`, `TransactionSignature`, and `sendAndConfirmTransaction`. No additional methods or definitions are required, and no other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._