### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/transfer-hook-service.ts
+++ b/transfer-hook-service.ts
@@ -14,8 +14,6 @@ import {
 } from '@solana/web3.js';
 import { 
   AnchorProvider, 
-  Program, 
-  BN 
 } from '@coral-xyz/anchor';
 import { 
   TOKEN_2022_PROGRAM_ID, 


### PR DESCRIPTION
To fix the issue, remove the unused imports `BN` and `Program` from the `@coral-xyz/anchor` import statement so that only `AnchorProvider` is imported. This keeps the file’s behavior identical while eliminating the unused symbols.

Concretely, in `transfer-hook-service.ts`, edit the import block around lines 15–19 so that it becomes:

```ts
import {
  AnchorProvider,
} from '@coral-xyz/anchor';
```

No other code changes, new methods, or additional imports are required. The rest of the file should continue to work as before because `BN` and `Program` are not used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._