### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/typescript/mintManager.ts
+++ b/typescript/mintManager.ts
@@ -1,4 +1,4 @@
-import { Connection, Keypair, PublicKey, Transaction, SystemProgram } from "@solana/web3.js";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import { TOKEN_2022_PROGRAM_ID, Token } from "@solana/spl-token";
  
 /**


### PR DESCRIPTION
In general, the correct fix for unused imports is to remove the specific identifiers that are not referenced anywhere in the file. This eliminates dead code, avoids confusion about unused dependencies, and can slightly reduce bundle size.

For this file, we should edit the import statement on line 1 in `typescript/mintManager.ts` to remove `Transaction` and `SystemProgram`, while leaving `Connection`, `Keypair`, and `PublicKey` intact. No other lines in the file need to change, because there are no references to the removed imports. We do not need to add any new methods, definitions, or imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._