### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/typescript/clients/registryClient.ts
+++ b/typescript/clients/registryClient.ts
@@ -32,7 +32,7 @@ export async function issueAttestation(
   dataHash: Uint8Array // 32 bytes
 ) {
   const program = await loadRegistryProgram(provider, programId);
-  const [attPda, bump] = await PublicKey.findProgramAddress(
+  const [attPda] = await PublicKey.findProgramAddress(
     [Buffer.from("attestation"), wallet.toBuffer()],
     program.programId
   );


### PR DESCRIPTION
In general, to fix an unused variable warning you either remove the variable or start using it meaningfully. Here, since the bump from `findProgramAddress` is not needed anywhere in `issueAttestation`, the best fix that preserves existing functionality is to stop binding it altogether. We still need the PDA (`attPda`), but the bump can safely be discarded.

Concretely, in `typescript/clients/registryClient.ts`, inside `issueAttestation`, change the destructuring assignment on the result of `PublicKey.findProgramAddress` so that only the first element (the PDA) is captured. This can be done by removing `, bump` from the array destructuring. No imports or additional methods are required: `findProgramAddress` is already in use, and we are only changing the local binding pattern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._