### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Monitor Script.ts
+++ b/Monitor Script.ts
@@ -1,5 +1,5 @@
 import { Program, AnchorProvider } from "@coral-xyz/anchor";
-import { Connection, PublicKey } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 
 export const startSanctionsMonitor = async (program: Program) => {
   console.log("🛡️ Sanctions Monitor Started...");


### PR DESCRIPTION
To fix the problem, we should remove the unused `Connection` import while leaving the used `PublicKey` import intact. This eliminates dead code, keeps the file cleaner, and silences the CodeQL warning without affecting runtime behavior.

Concretely, in `Monitor Script.ts`, modify the second import statement so that it only imports `PublicKey` from `@solana/web3.js`. No other lines or behavior need to change, since `Connection` is not referenced anywhere else. No additional methods, definitions, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._