### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/next Unit Tests tests/unit/sdk-client.test.ts
+++ b/next Unit Tests tests/unit/sdk-client.test.ts
@@ -1,5 +1,5 @@
 import { SolanaKYCClient } from '../../src/client';
-import { Connection, Keypair } from '@solana/web3.js';
+import { Keypair } from '@solana/web3.js';
 import { Environment } from '../../src/utils/env';
 
 describe('SolanaKYCClient', () => {


### PR DESCRIPTION
In general, the correct fix for an unused import is to remove that specific symbol from the import statement, or remove the entire import if none of its symbols are used. This keeps the code clean, avoids warnings, and does not alter runtime behavior.

For this file, we should update the import statement on line 2 in `tests/unit/sdk-client.test.ts` to remove `Connection` while leaving `Keypair`, which is used in `beforeAll` to generate `testWallet`. Specifically:
- Change `import { Connection, Keypair } from '@solana/web3.js';`
- To `import { Keypair } from '@solana/web3.js';`

No additional methods, imports, or definitions are required elsewhere, and no test logic needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._