### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/test/kyc-integration.test.ts
+++ b/test/kyc-integration.test.ts
@@ -1,7 +1,7 @@
 // This goes ONLY in solana-kyc-sdk repo
 import { SolanaKYCClient } from '../src';
 import { Connection, Keypair } from '@solana/web3.js';
-import { describe, test, expect, beforeAll } from '@jest/globals';
+import { describe, test, beforeAll } from '@jest/globals';
 
 describe('KYC SDK Integration', () => {
   let kycClient: SolanaKYCClient;


### PR DESCRIPTION
To fix the problem, remove the unused `expect` named import from the `@jest/globals` import statement while leaving the other used imports intact. This preserves all existing functionality (the tests still run with `describe`, `test`, and `beforeAll`) and simply eliminates a dead import that triggers the CodeQL warning.

Concretely, in `test/kyc-integration.test.ts`, update the import on line 4 from:

```ts
import { describe, test, expect, beforeAll } from '@jest/globals';
```

to:

```ts
import { describe, test, beforeAll } from '@jest/globals';
```

No additional methods, definitions, or imports are required; we are only trimming the unused symbol from the existing import list.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._