### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Monitor Script.ts
+++ b/Monitor Script.ts
@@ -1,4 +1,4 @@
-import { Program, AnchorProvider } from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
 import { PublicKey } from "@solana/web3.js";
 
 export const startSanctionsMonitor = async (program: Program) => {


### PR DESCRIPTION
To fix the problem, remove the unused `AnchorProvider` named import from the import statement. This keeps the code clean and aligns with the CodeQL rule, without changing runtime behavior.

Concretely, in `Monitor Script.ts`, edit line 1 to only import `Program` from `@coral-xyz/anchor`. No additional methods, imports, or definitions are required, and no other lines need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._