### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/deploy-programs.ts
+++ b/deploy-programs.ts
@@ -14,7 +14,6 @@ import {
 } from '@solana/web3.js';
 import { AnchorProvider, Wallet } from '@coral-xyz/anchor';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as yaml from 'yaml';
 
 /**


### PR DESCRIPTION
To fix an unused import, remove it from the file so the code only imports what it actually uses. This keeps the codebase cleaner, avoids confusion about unused dependencies, and satisfies the static analysis rule.

In this case, the best fix is to delete the `import * as path from 'path';` line in `deploy-programs.ts`. No other code changes are required, since there are no references to `path` in the provided snippet. We also do not need to add any new methods, definitions, or imports; we are only removing the unused one.

Concretely:
- In `deploy-programs.ts`, around line 17, remove the entire line `import * as path from 'path';`.
- Keep the surrounding imports (`fs`, `yaml`, etc.) unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._