### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/typescript/registryClient.ts
+++ b/typescript/registryClient.ts
@@ -22,7 +22,7 @@ export async function buildIssueAttestationIx(
   provider: anchor.AnchorProvider,
   params: IssueParams
 ): Promise<TransactionInstruction> {
-  const { issuer, wallet, expiresAt, jurisdiction, dataHash, programId } = params;
+  const { wallet, programId } = params;
   const [attestationPda, bump] = await PublicKey.findProgramAddress(
     [Buffer.from("attestation"), wallet.toBuffer()],
     programId


### PR DESCRIPTION
General fix: Remove or use variables that are destructured but not actually used. In this case, since the function is a template that unconditionally throws, the minimal, behavior-preserving fix is to stop destructuring `jurisdiction` (and, for cleanliness, other unused variables) from `params`.

Best concrete fix: Change the destructuring on line 25 to only pull out the fields that are actually referenced in the function body (`wallet` and `programId`). This keeps the function signature and `IssueParams` type intact (no external behavior change) while eliminating the unused variable `jurisdiction` that CodeQL flags. No new imports or helper methods are needed.

Specifically, in `typescript/registryClient.ts`, replace:

```ts
const { issuer, wallet, expiresAt, jurisdiction, dataHash, programId } = params;
```

with:

```ts
const { wallet, programId } = params;
```

This preserves all existing behavior (the function still throws as before) and resolves the unused variable warning for `jurisdiction` (and also cleans up other unused bindings).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._