### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/kyc-compliance-sdk.ts
+++ b/src/kyc-compliance-sdk.ts
@@ -1,5 +1,5 @@
 import { Connection, PublicKey, clusterApiUrl } from '@solana/web3.js';
-import * as anchor from '@coral-xyz/anchor';
+
 
 // =======================================================================
 // === ACTION REQUIRED: REPLACE THESE PLACEHOLDERS WITH ACTUAL VALUES ===


### PR DESCRIPTION
In general, unused imports should be removed to avoid dead code, reduce bundle size, and eliminate confusion about dependencies. The best fix here is to delete the unused `anchor` import from `@coral-xyz/anchor`, leaving the rest of the file intact.

Concretely, in `src/kyc-compliance-sdk.ts`, remove line 2 that imports `anchor`. No other code in the snippet refers to `anchor`, so this change does not affect existing functionality. No new methods, definitions, or additional imports are required. After the change, the file will only import from `@solana/web3.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._