### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Test Files sdk/tests/compliance-sdk.test.ts
+++ b/Test Files sdk/tests/compliance-sdk.test.ts
@@ -1,5 +1,5 @@
 import { ComplianceSDK } from '../src/compliance-sdk';
-import { Connection, Keypair, PublicKey } from '@solana/web3.js';
+import { Keypair, PublicKey } from '@solana/web3.js';
 import { WalletNotConnectedError, TransferDeniedByHookError } from '../src/errors';
 
 // Mock web3.js and spl-token


### PR DESCRIPTION
To fix the problem, we should remove the unused `Connection` named import from `@solana/web3.js` and keep only the actually used imports (`Keypair` and `PublicKey`). This preserves all existing functionality while eliminating the unused symbol.

Concretely, in `Test Files sdk/tests/compliance-sdk.test.ts`, edit the import on line 2 from:

```ts
import { Connection, Keypair, PublicKey } from '@solana/web3.js';
```

to:

```ts
import { Keypair, PublicKey } from '@solana/web3.js';
```

No additional methods, imports, or definitions are required. This is purely a cleanup change to the import list.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._