### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/typescript/registryClient.ts
+++ b/typescript/registryClient.ts
@@ -23,7 +23,7 @@ export async function buildIssueAttestationIx(
   params: IssueParams
 ): Promise<TransactionInstruction> {
   const { wallet, programId } = params;
-  const [attestationPda, bump] = await PublicKey.findProgramAddress(
+  const [attestationPda] = await PublicKey.findProgramAddress(
     [Buffer.from("attestation"), wallet.toBuffer()],
     programId
   );


### PR DESCRIPTION
In general, to fix an unused-variable issue, either start using the variable meaningfully, or stop binding it in the first place (or explicitly mark it as intentionally unused). Here, the function already uses only the first element of the tuple returned by `PublicKey.findProgramAddress`, so the best minimal fix is to destructure only that element and drop `bump`.

Concretely, in `typescript/registryClient.ts`, update the destructuring on line 26 from `[attestationPda, bump] = ...` to `[attestationPda] = ...`. This preserves the computation of `attestationPda` exactly as before, removes the unused `bump` variable, and does not alter existing functionality (the function still throws as before). No new methods, imports, or type changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._