### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/test/zk-proofs.test.ts
+++ b/test/zk-proofs.test.ts
@@ -7,7 +7,6 @@
 
 import { describe, test, expect, beforeAll } from '@jest/globals';
 import { ZKKYCVerifier, ZKProof, ZKPublicSignals } from '../src/zk-kyc';
-import { groth16 } from 'snarkjs'; // Assuming use of snarkjs/groth16
 // import { buildPoseidon } from 'circomlibjs'; // If using Poseidon hashing
 
 let zkVerifier: ZKKYCVerifier;


### PR DESCRIPTION
To fix the problem, remove the unused `groth16` named import from `'snarkjs'`. This resolves the CodeQL warning without changing any test behavior, since the symbol is not used and does not provide side effects when imported this way.

Concretely, in `test/zk-proofs.test.ts`, delete line 10 that imports `groth16`. Keep the surrounding imports (Jest globals and `ZKKYCVerifier` etc.) unchanged. No additional methods, definitions, or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._