### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/typescript/registryClient.ts
+++ b/typescript/registryClient.ts
@@ -23,7 +23,7 @@ export async function buildIssueAttestationIx(
   params: IssueParams
 ): Promise<TransactionInstruction> {
   const { wallet, programId } = params;
-  const [attestationPda] = await PublicKey.findProgramAddress(
+  await PublicKey.findProgramAddress(
     [Buffer.from("attestation"), wallet.toBuffer()],
     programId
   );


### PR DESCRIPTION
In general, unused variable warnings are fixed by either using the variable in real logic or removing the binding if the value is not needed. Here, the function is a template that throws unconditionally, so there is no actual use of `attestationPda`. To fix the CodeQL warning without changing existing behavior, we should stop binding the return value to a named variable. That keeps the example call to `PublicKey.findProgramAddress` in place (useful as a template) while eliminating the unused variable.

The single best change is to replace the destructuring assignment `const [attestationPda] = await PublicKey.findProgramAddress(...)` with a bare `await PublicKey.findProgramAddress(...)` call whose result is ignored. This preserves any potential side effects of the call (if any), keeps the template logic visible, and removes the unused variable. Concretely, in `typescript/registryClient.ts`, at lines 25–29, change the line that declares `attestationPda` to just an awaited function call, without introducing a new variable or changing any imports or other code.

No additional methods, imports, or type definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._