### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/test/sas-integration.test.ts
+++ b/test/sas-integration.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, test, expect, beforeAll } from '@jest/globals';
-import { Connection, Keypair, PublicKey } from '@solana/web3.js';
+import { Connection, Keypair } from '@solana/web3.js';
 import { SolanaKYCClient, SASAttestation } from '../src/sas-integration';
 
 const DEVNET_RPC = 'https://api.devnet.solana.com';


### PR DESCRIPTION
To fix the problem, remove the unused `PublicKey` named import from `@solana/web3.js` so that only the actually used symbols are imported. This eliminates the unused import, cleans up the code, and does not affect runtime behaviour because named imports have no side effects by themselves.

Concretely, in `test/sas-integration.test.ts`, update the import on line 9 from `import { Connection, Keypair, PublicKey } from '@solana/web3.js';` to `import { Connection, Keypair } from '@solana/web3.js';`. No other code changes or additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._