### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Custom Compliance Hook.ts
+++ b/Custom Compliance Hook.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
 import { AnchorProvider, Program } from '@coral-xyz/anchor';
-import { IdentityManager, ComplianceFlags } from '@gitdigital/compliance-sdk';
+import { IdentityManager } from '@gitdigital/compliance-sdk';
 
 export function useComplianceManager() {
   const { connection } = useConnection();


### PR DESCRIPTION
To fix the problem, remove the unused `ComplianceFlags` from the import statement so that only `IdentityManager` is imported. This preserves existing functionality, since `ComplianceFlags` is not referenced anywhere in the function and has no apparent side-effect usage.

Concretely:
- In `Custom Compliance Hook.ts`, edit the import on line 4.
- Change `import { IdentityManager, ComplianceFlags } from '@gitdigital/compliance-sdk';` to `import { IdentityManager } from '@gitdigital/compliance-sdk';`.
- No other code, imports, methods, or definitions need to be added or modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._