### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Environment Helper Utility src/utils/env.ts
+++ b/Environment Helper Utility src/utils/env.ts
@@ -1,5 +1,4 @@
 import dotenv from 'dotenv';
-import path from 'path';
 
 // Load environment variables
 dotenv.config();


### PR DESCRIPTION
In general, unused imports should be removed to keep the code clean and avoid confusion about dependencies or intended functionality. Since there are no references to `path` in `src/utils/env.ts`, the best fix is to delete the `import path from 'path';` line.

Concretely, in `src/utils/env.ts`, remove line 2 containing `import path from 'path';`. No other code changes are needed because the rest of the file does not depend on `path`, and removing this import will not alter behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._