### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/examples/circle-api-integration.ts
+++ b/examples/circle-api-integration.ts
@@ -38,7 +38,6 @@ export async function createCompliantUSDCTransfer(
   
   // Convert addresses to PublicKey objects
   const senderPubKey = new PublicKey(senderWalletAddress);
-  const recipientPubKey = new PublicKey(recipientWalletAddress);
   
   // Verify the sender has a valid, non-revoked KYC attestation from a trusted issuer[citation:2][citation:10]
   const kycStatus = await kycClient.verifySASAttestation(senderPubKey, 'kyc/v1', kycIssuer);


### PR DESCRIPTION
In general, the way to fix this kind of issue is either to (a) remove the unused variable/import/function if it truly is unnecessary, or (b) integrate it into the logic if it reflects an intended but unimplemented behavior. Since we must not change existing behavior, and there is no indication that `recipientPubKey` is required for any current functionality, the safest fix is to remove its declaration.

Concretely, in `examples/circle-api-integration.ts`, within the `createCompliantUSDCTransfer` function, we will delete the line that declares `recipientPubKey`. The `senderPubKey` remains, as it is used by `kycClient.verifySASAttestation`. No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._