### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/frontend/components/KycStatus.tsx
+++ b/frontend/components/KycStatus.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { PublicKey } from "@solana/web3.js";
-import { attestationPda, REGISTRY_PROGRAM_ID } from "../utils/anchorClient";
- 
+import { attestationPda } from "../utils/anchorClient";
+ 
 export default function KycStatus({ wallet }: { wallet: string | null }) {
   const [status, setStatus] = useState<string | null>(null);
 


### PR DESCRIPTION
In general, to fix an unused import issue, you remove the unused symbol from the import statement (or delete the entire import if nothing in it is used). This eliminates dead code and makes the file clearer.

Here, the best fix is to edit `frontend/components/KycStatus.tsx` so that it only imports `attestationPda` from `"../utils/anchorClient"`. `REGISTRY_PROGRAM_ID` is never referenced in the component, so its removal will not affect runtime behavior. No additional imports, methods, or definitions are required.

Concretely:
- In `frontend/components/KycStatus.tsx`, locate the import on line 3.
- Change `import { attestationPda, REGISTRY_PROGRAM_ID } from "../utils/anchorClient";` to `import { attestationPda } from "../utils/anchorClient";`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._