### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/test/kyc-integration.test.ts
+++ b/test/kyc-integration.test.ts
@@ -1,6 +1,6 @@
 // This goes ONLY in solana-kyc-sdk repo
 import { SolanaKYCClient } from '../src';
-import { Connection, Keypair } from '@solana/web3.js';
+import { Connection } from '@solana/web3.js';
 import { describe, test, beforeAll } from '@jest/globals';
 
 describe('KYC SDK Integration', () => {


### PR DESCRIPTION
In general, to fix unused import warnings, either remove the unused identifier from the import statement or start using it meaningfully in the code. Since there is no current usage of `Keypair` in this test file, and adding artificial usage would change the test behavior or add dead code, the best fix is to remove `Keypair` from the import list.

Concretely, in `test/kyc-integration.test.ts`, update the import on line 3 from `import { Connection, Keypair } from '@solana/web3.js';` to only import `Connection`. No other lines in this file need to change, and no new methods or definitions are required for this fix. We also do not need any additional imports or external libraries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._