### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/examples/create_mint.ts
+++ b/examples/create_mint.ts
@@ -1,6 +1,6 @@
 import { Keypair } from "@solana/web3.js";
  
+ 
  
-const payer = Keypair.generate();
- 
- 
+ 
+ 


### PR DESCRIPTION
In general, to fix an unused variable warning, either remove the variable declaration if it truly is not needed, or update the code to actually use it if it was intended to serve a purpose. For example files, the cleanest fix is usually to remove unused declarations so the example is minimal and free of noise.

For this specific case, the best way to fix the problem without changing existing functionality is to remove the `payer` variable declaration on line 4. The snippet only shows `payer` and `mint` being generated, with no further context; since `mint` is presumably used later and `payer` is not, deleting the `payer` declaration will not affect runtime behavior, because unused variables do not influence program output. No imports, methods, or other definitions need to be added: the only change is to eliminate the unused variable line from `examples/create_mint.ts`.

Concretely, in `examples/create_mint.ts`, delete line 4 (`const payer = Keypair.generate();`) and leave the rest of the file unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._