### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/examples/create_mint.ts
+++ b/examples/create_mint.ts
@@ -1,6 +1,6 @@
-import { Keypair } from "@solana/web3.js";
- 
- 
- 
- 
- 
+
+
+
+
+
+


### PR DESCRIPTION
In general, to fix an unused import warning, either remove the import if the symbol is not needed, or add code that legitimately uses the imported symbol. Since the provided file contains only the import and no other logic, the lowest-risk change that does not alter existing functionality is to delete the unused import.

Concretely, in `examples/create_mint.ts`, remove line 1 (`import { Keypair } from "@solana/web3.js";`). This eliminates the unused import without affecting any other logic, because there is no code in the snippet that depends on it. No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._