### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/examples/circle-api-integration.ts
+++ b/examples/circle-api-integration.ts
@@ -5,7 +5,7 @@
  * with a prerequisite KYC check using the GitDigital KYC SDK.
  */
 
-import { Connection, PublicKey, Transaction } from '@solana/web3.js';
+import { Connection, PublicKey } from '@solana/web3.js';
 import { SolanaKYCClient } from '../src/sas-integration';
 import { ZKKYCVerifier } from '../src/zk-kyc';
 


### PR DESCRIPTION
To fix the problem, remove the unused `Transaction` import while leaving the used imports (`Connection` and `PublicKey`) intact. This preserves all existing functionality because `Transaction` is not referenced anywhere in the file, and its removal only affects static analysis/lint cleanliness.

Concretely, in `examples/circle-api-integration.ts`, edit the import on line 8 to drop `Transaction` from the destructuring import. No other code changes, new methods, or additional imports are needed, because there is no usage of `Transaction` to update or replace.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._