### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/deploy-programs.ts
+++ b/deploy-programs.ts
@@ -9,8 +9,6 @@ import {
   Connection, 
   Keypair, 
   PublicKey, 
-  Transaction,
-  sendAndConfirmTransaction,
 } from '@solana/web3.js';
 import { AnchorProvider, Wallet } from '@coral-xyz/anchor';
 import * as fs from 'fs';


### PR DESCRIPTION
In general, unused imports should be removed to keep the codebase clean, avoid misleading readers, and prevent minor tooling or compilation warnings. Since `Transaction` and `sendAndConfirmTransaction` are reported as unused and we have no evidence they are needed elsewhere in this file, the safest fix that does not change existing functionality is to delete these two names from the import statement.

Concretely, in `deploy-programs.ts`, edit the `@solana/web3.js` import on lines 8–14 to only include the actually used symbols: `Connection`, `Keypair`, and `PublicKey`. Remove `Transaction` and `sendAndConfirmTransaction` from the destructuring list. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._