### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/test/sas-integration.test.ts
+++ b/test/sas-integration.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, test, expect, beforeAll } from '@jest/globals';
 import { Connection, Keypair } from '@solana/web3.js';
-import { SolanaKYCClient, SASAttestation } from '../src/sas-integration';
+import { SolanaKYCClient } from '../src/sas-integration';
 
 const DEVNET_RPC = 'https://api.devnet.solana.com';
 let connection: Connection;


### PR DESCRIPTION
In general, unused imports should be removed to reduce noise and avoid misleading future readers into thinking a symbol is used. Here, the single unused symbol is `SASAttestation` in the import from `../src/sas-integration`. The safest fix that does not alter functionality is to adjust that import statement to only import `SolanaKYCClient`, which is actually used in the tests.

Concretely, in `test/sas-integration.test.ts`, on the import line currently reading `import { SolanaKYCClient, SASAttestation } from '../src/sas-integration';`, remove `SASAttestation` and the trailing comma. No additional methods, definitions, or imports are needed, since nothing else depends on `SASAttestation`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._