### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/typescript/registryClient.ts
+++ b/typescript/registryClient.ts
@@ -28,11 +28,6 @@ export async function buildIssueAttestationIx(
     programId
   );
 
-  // build instruction data using Anchor IDL or manual serialization
-  const ixData = new anchor.BorshInstructionCoder({
-    // for quick prototyping use anchor's program client / IDL
-  } as any);
-
   // For brevity: example using anchor Program (you should instantiate Program with IDL)
   throw new Error("Use Anchor program client to build this instruction. Example template below.");
 


### PR DESCRIPTION
In general, to fix an unused-variable issue you either (a) remove the declaration if it is not needed, or (b) actually use the variable in the logic. Here, the function throws unconditionally and the comments clearly mark this as a template that should be implemented using the Anchor program client. The simplest, non‑functional fix is to remove the unused `ixData` variable and its associated comments, leaving the instructional error intact. This does not change existing runtime behavior (the function still throws) but eliminates the dead code.

Concretely, in `typescript/registryClient.ts`, inside `buildIssueAttestationIx`, delete lines 31–34 that construct `ixData` with `new anchor.BorshInstructionCoder(...)`. No additional imports, methods, or definitions are necessary, since we are only removing unused code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._