### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/kyc-flow.test.ts
+++ b/kyc-flow.test.ts
@@ -9,8 +9,6 @@ import {
   Connection, 
   Keypair, 
   PublicKey, 
-  Transaction,
-  sendAndConfirmTransaction 
 } from '@solana/web3.js';
 import { AnchorProvider, Wallet } from '@coral-xyz/anchor';
 import { ComplianceSDK, KycLevel, KycStatus } from '../../sdk/src/compliance-sdk';


### PR DESCRIPTION
To fix the problem, we should remove the unused imports `Transaction` and `sendAndConfirmTransaction` from the import statement that pulls from `@solana/web3.js`. This keeps the codebase clean and resolves the CodeQL warning without changing any behavior, since unused imports have no runtime effect in TypeScript/JavaScript.

Concretely, in `kyc-flow.test.ts`, update the import block at the top of the file (lines 8–14) so that it only imports `Connection`, `Keypair`, and `PublicKey`. No additional code changes are necessary, and we do not need to add any new methods, definitions, or imports elsewhere. The rest of the file remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._