### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/typescript/mintManager.ts
+++ b/typescript/mintManager.ts
@@ -1,5 +1,5 @@
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
-import { TOKEN_2022_PROGRAM_ID, Token } from "@solana/spl-token";
+
  
 /**
  * Deploy a new SPL Token-2022 mint with metadata to set Transfer Hook and Permanent Delegate.


### PR DESCRIPTION
To fix the problem, remove the unused imports from `@solana/spl-token` so that only imports that are actually referenced in this file remain. This eliminates the CodeQL warning and keeps the module clean and easier to maintain, without changing existing runtime functionality (the functions already either throw or just use `PublicKey` and `Buffer`).

Concretely, in `typescript/mintManager.ts`, delete the import line `import { TOKEN_2022_PROGRAM_ID, Token } from "@solana/spl-token";`. No other changes are needed: there are no references to `TOKEN_2022_PROGRAM_ID` or `Token`, and all other imports on line 1 are used (`Connection`, `Keypair`, `PublicKey`). This preserves the existing API surface (`export`ed functions) and behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._