### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Initialize the client.ts
+++ b/Initialize the client.ts
@@ -1,6 +1,6 @@
 import { ComplianceClient } from "@gitdigital/solana-kyc-compliance-sdk";
 
-const client = new ComplianceClient({
+new ComplianceClient({
   cluster: "mainnet-beta",
   apiKey: process.env.KYC_API_KEY,
 });


### PR DESCRIPTION
In general, to fix an "unused variable" issue you either remove the variable (and any dependent code) if it is truly unnecessary, or you start using it if some logic is missing. When the constructor’s side effects are needed but the variable is not, you can call the constructor without assigning the instance to a variable.

For this snippet, the best fix that doesn’t change behavior is to remove the `client` binding and just instantiate `ComplianceClient`. That way, any side effects from construction still happen, but there is no unused variable. Concretely, in `Initialize the client.ts`, replace `const client = new ComplianceClient({ ... });` with `new ComplianceClient({ ... });`. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._