### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/sdk/scripts/workflow-example.ts
+++ b/sdk/scripts/workflow-example.ts
@@ -5,7 +5,7 @@
  */
 
 import { ComplianceSDK } from '../src/compliance-sdk';
-import { Connection, Keypair, clusterApiUrl, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import { Connection, Keypair, clusterApiUrl } from '@solana/web3.js';
 import { WalletNotConnectedError, TransferDeniedByHookError } from '../src/errors';
 
 async function main() {


### PR DESCRIPTION
In general, to fix unused import issues, you either (1) remove the unused import, if it is truly unnecessary, or (2) add code that uses the imported symbol, if it was meant to be used but was accidentally omitted. The goal is to align the import list with the actual usage in the file.

For this concrete case, the best fix without changing existing functionality is to remove `LAMPORTS_PER_SOL` from the import list on line 8. Nothing in `sdk/scripts/workflow-example.ts` uses it, and we are not changing any logic by eliminating it. We will modify only the import statement at the top of `sdk/scripts/workflow-example.ts`, keeping the rest of the file intact. No additional methods, definitions, or imports are needed.

Concretely:
- In `sdk/scripts/workflow-example.ts`, edit the `@solana/web3.js` import so it only imports `Connection`, `Keypair`, and `clusterApiUrl`.
- Do not add any new dependencies or change other code blocks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._