### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/ExtraAccountMetaList PDA.ts
+++ b/ExtraAccountMetaList PDA.ts
@@ -1,8 +1,4 @@
 import * as anchor from "@coral-xyz/anchor";
-import { 
-  getExtraAccountMetaAddress, 
-  getTransferHookInstruction 
-} from "@solana/spl-token";
 
 export async function initializeExtraAccounts(
   program: anchor.Program<any>,


### PR DESCRIPTION
In general, to fix unused-import issues, remove the unused names from the import statement (or delete the entire import if nothing from that module is used). This keeps the codebase clean, avoids confusion over unused functionality, and can slightly improve build times and bundle size.

For this specific file `ExtraAccountMetaList PDA.ts`, the best minimal fix that preserves existing functionality is to delete the import of `getExtraAccountMetaAddress` and `getTransferHookInstruction` entirely, since nothing from `@solana/spl-token` is used in the snippet. No additional code is required; we simply remove lines 2–5. The rest of the function `initializeExtraAccounts` remains unchanged, and no new imports or definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._