### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/sdk/src/instructions/index.ts
+++ b/sdk/src/instructions/index.ts
@@ -6,8 +6,6 @@ import {
 } from '@solana/web3.js';
 import {
   TOKEN_2022_PROGRAM_ID,
-  getAssociatedTokenAddressSync,
-  createAssociatedTokenAccountInstruction,
 } from '@solana/spl-token';
 import { findExtraAccountsMetaPda } from '../utils';
 


### PR DESCRIPTION
In general, unused imports should be removed from the file to avoid dead code, potential confusion, and to satisfy static analysis tools. This does not change runtime behavior so long as the imports were not relied upon for side effects.

The best fix here is to adjust the `@solana/spl-token` import so that it only imports the identifiers that are actually used in `sdk/src/instructions/index.ts`. In the snippet, we see `TOKEN_2022_PROGRAM_ID` imported along with `getAssociatedTokenAddressSync` and `createAssociatedTokenAccountInstruction`. Since only the latter two are flagged as unused, we should remove them from the import list, leaving `TOKEN_2022_PROGRAM_ID` untouched. No other code changes are needed.

Concretely:
- In `sdk/src/instructions/index.ts`, on lines 7–11, update the `@solana/spl-token` import to remove `getAssociatedTokenAddressSync` and `createAssociatedTokenAccountInstruction`, retaining only `TOKEN_2022_PROGRAM_ID`.
- No additional methods, definitions, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._