### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/typescript/registryClient.ts
+++ b/typescript/registryClient.ts
@@ -4,7 +4,6 @@ import {
   PublicKey,
   TransactionInstruction,
   Keypair,
-  SystemProgram,
 } from "@solana/web3.js";
 import * as anchor from "@project-serum/anchor";
  


### PR DESCRIPTION
In general, unused imports should be removed to keep the code clean, avoid confusion about intended functionality, and prevent linting/static analysis errors. Since `SystemProgram` is not used anywhere in the provided code, the safest, behavior-preserving fix is to delete it from the import list.

Concretely, in `typescript/registryClient.ts`, adjust the `@solana/web3.js` named import list to remove `SystemProgram`. No other changes are required: we do not need new methods, imports, or definitions, because this is only a cleanup of an unused symbol. The module will still import `Connection`, `PublicKey`, `TransactionInstruction`, and `Keypair` exactly as before.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._