### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Service Layer sdk/src/services/transfer-hook-service.ts
+++ b/Service Layer sdk/src/services/transfer-hook-service.ts
@@ -1,7 +1,6 @@
 import {
   Connection,
   PublicKey,
-  Signer,
   Transaction,
   TransactionSignature,
   sendAndConfirmTransaction,


### PR DESCRIPTION
To fix the problem, we should remove the unused `Signer` symbol from the import list from `@solana/web3.js`. This keeps the import clean, avoids linter/CodeQL warnings, and does not alter runtime behavior, since unused imports have no side effects here (the module is still imported for the remaining used symbols).

Concretely, in `Service Layer sdk/src/services/transfer-hook-service.ts`, update the first import statement to drop `Signer` from the destructuring list. No other changes to functionality, imports, or code are necessary, as `Signer` is not referenced anywhere in the provided code. No additional methods or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._