### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/core sdk files sdk/src/compliance-sdk.ts
+++ b/core sdk files sdk/src/compliance-sdk.ts
@@ -1,4 +1,4 @@
-import { Connection, PublicKey, Signer, TransactionSignature } from '@solana/web3.js';
+import { TransactionSignature } from '@solana/web3.js';
 import { TransferHookService } from './services/transfer-hook-service';
 import {
   InitializeCompliantMintParams,


### PR DESCRIPTION
General fix: Remove the unused imports (`Connection`, `PublicKey`, `Signer`) from the import statement while keeping `TransactionSignature`, which is used as a return type in the class methods.

Concrete change for this file:

- In `sdk/src/compliance-sdk.ts`, edit the first import line to only import `TransactionSignature` from `@solana/web3.js`.
- No other lines or behavior need to change.
- No new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._