### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Health Check Script scripts/deploy-tools/health-check.ts
+++ b/Health Check Script scripts/deploy-tools/health-check.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env ts-node
-import { Connection, PublicKey, clusterApiUrl } from '@solana/web3.js';
+import { Connection, PublicKey } from '@solana/web3.js';
 import { SolanaKYCClient } from '../../src/client';
 import { Environment } from '../../src/utils/env';
 import axios from 'axios';


### PR DESCRIPTION
To fix the problem, we should remove the unused symbol `clusterApiUrl` from the import statement on line 2 so that only the actually used types/functions are imported. This aligns with common TypeScript/JavaScript style, avoids misleading future readers, and resolves the CodeQL warning.

Concretely, in `scripts/deploy-tools/health-check.ts`, edit the import on line 2 from:

```ts
import { Connection, PublicKey, clusterApiUrl } from '@solana/web3.js';
```

to:

```ts
import { Connection, PublicKey } from '@solana/web3.js';
```

No other lines in the file need to change, and no new methods or definitions are required. This keeps existing functionality intact, since `clusterApiUrl` was never used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._