### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Integration Tests tests/integration/kyc-flow.test.ts
+++ b/Integration Tests tests/integration/kyc-flow.test.ts
@@ -131,15 +131,6 @@ describe('KYC Flow Integration', () => {
 
   describe('Error Recovery', () => {
     test('should recover from RPC timeout', async () => {
-      // Create a connection with very short timeout
-      const fastConnection = new Connection(
-        Environment.getSolanaRpcUrl(),
-        {
-          commitment: 'processed',
-          confirmTransactionInitialTimeout: 1000 // 1 second timeout
-        }
-      );
-
       const fastClient = new SolanaKYCClient({
         rpcUrl: Environment.getSolanaRpcUrl(),
         network: Environment.getSolanaNetwork(),


### PR DESCRIPTION
In general, unused variables should be removed or, if they were meant to be used, the code should be updated so they serve a real purpose. Here the best minimal fix that preserves existing functionality is to remove the unused `fastConnection` declaration entirely, because the test already uses `fastClient` (with a comment about “very short timeout”) and never needs `fastConnection`.

Concretely, in `tests/integration/kyc-flow.test.ts`, within the `describe('Error Recovery', ...)` block and test `'should recover from RPC timeout'`, delete the block that defines `fastConnection` (lines 134–141). No new imports or helper methods are needed. This resolves the CodeQL warning without altering the behavior of the test, since that variable was not used anywhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._