### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/other admin-dashboard/components/Riskdashboard.jsx
+++ b/other admin-dashboard/components/Riskdashboard.jsx
@@ -5,7 +5,6 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Progress } from '@/components/ui/progress';
 import { 
   Search, 


### PR DESCRIPTION
In general, unused imports should be removed to keep the codebase clean, avoid confusion, and eliminate minor overhead in bundling and linting. If the functionality they were meant to support is no longer present, deleting them is the correct fix; if they are actually needed, the fix would instead be to add or restore the corresponding usage.

For this file, the best fix without altering behavior is to delete the line importing `Tabs`, `TabsContent`, `TabsList`, and `TabsTrigger` from `@/components/ui/tabs`. No other code references these symbols, so no additional changes are necessary. Specifically, update `other admin-dashboard/components/Riskdashboard.jsx` by removing line 8 (`import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';`) and leaving the rest of the imports and component code unchanged. No new methods or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._