### PR TITLE
Fix for Property access on null or undefined

### DIFF
--- a/other admin-dashboard/components/Riskdashboard.jsx
+++ b/other admin-dashboard/components/Riskdashboard.jsx
@@ -38,9 +38,6 @@ const RiskDashboard = () => {
 
   const fetchDashboardStats = async () => {
     try {
-      if (!response.ok) {
-        throw new Error(`Failed to fetch dashboard stats: ${response.status} ${response.statusText}`);
-      }
       const response = await fetch('/api/risk/dashboard/stats');
       if (!response.ok) {
         throw new Error(`Failed to fetch dashboard stats: ${response.status} ${response.statusText}`);
@@ -51,9 +48,6 @@ const RiskDashboard = () => {
       console.error('Failed to fetch dashboard stats:', error);
     }
   };
-      if (!response.ok) {
-        throw new Error(`Failed to fetch recent alerts: ${response.status} ${response.statusText}`);
-      }
 
   const fetchRecentAlerts = async () => {
     try {


### PR DESCRIPTION
In general, to fix this kind of problem you must ensure you never access properties on variables that may be `undefined` or `null`, either by initializing them before use or by removing/guarding the invalid access. Here, the problem is a premature use of `response.ok` before `response` is defined, likely due to a copy-paste or merge error.

The best fix without changing existing functionality is to remove the stray, invalid `if (!response.ok) { ... }` block before `response` is declared, and also remove the stray similar block outside any function at line 54–56. The correct logic already exists inside `fetchDashboardStats` and `fetchRecentAlerts` after their respective `fetch` calls, so deleting the erroneous blocks will not change runtime behavior except to eliminate the potential exception and syntax/parse issues.

Concretely:
- In `Riskdashboard.jsx`, inside `fetchDashboardStats`, delete the `if (!response.ok)` block that appears before `const response = await fetch(...)`.
- Also delete the orphaned `if (!response.ok)` block at lines 54–56 that sits outside of any function, leaving only the properly scoped `fetchRecentAlerts` implementation starting at line 58.
No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._