### PR TITLE
Potential fix for code scanning alert no. 20: Insecure randomness

### DIFF
--- a/base.ts
+++ b/base.ts
@@ -5,6 +5,7 @@
 
 import type { UserData, KYCSession, VerificationResult } from '../../types/identity';
 import type { ComplianceLevel } from '../../types/index';
+import * as crypto from 'crypto';
 
 /**
  * Base KYC Provider interface
@@ -348,7 +349,8 @@ export class GoogleIdentityProvider implements KYCProvider {
   }
 
   private generateSessionId(): string {
-    return `ggl_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    const randomSuffix = crypto.randomBytes(16).toString('hex');
+    return `ggl_${Date.now()}_${randomSuffix}`;
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/20](https://github.com/Gitdigital-products/solana-kyc-compliance-sdk/security/code-scanning/20)

In general, the fix is to stop using `Math.random()` for anything that might be security‑sensitive (such as session IDs, tokens, or secrets) and instead use a cryptographically secure pseudo‑random number generator (CSPRNG). In Node.js/TypeScript this is typically `crypto.randomBytes`; in browsers it is `crypto.getRandomValues`. The resulting random bytes can then be encoded (for example, as hex or base64) and composed into the existing ID format.

In this specific case, we should modify the private `generateSessionId()` method of `GoogleIdentityProvider` to replace the `Math.random().toString(36).substr(2, 9)` fragment with a CSPRNG‑based string, while preserving the overall shape of the ID (`ggl_<timestamp>_<random-part>`). Because this file appears to be part of a Node‑targeted SDK (and the recommendation text also calls out Node’s `crypto`), we can import Node’s built‑in `crypto` module at the top of `base.ts` and then use `crypto.randomBytes(16).toString('hex')` to generate a 32‑character hex string. No changes are required to callers, since the return type remains `string`.

Concretely:
- Add `import * as crypto from 'crypto';` near the top of `base.ts` without altering existing imports.
- Update `generateSessionId()` to call a new `generateSecureRandomIdPart()` helper or directly use `crypto.randomBytes` to produce the random suffix instead of `Math.random`.
- Keep the prefix `ggl_` and timestamp to avoid changing expectations about ID shape.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
